### PR TITLE
Ajuste no .gitignore e melhorias no script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,103 @@
-password.txt
+# Created by https://www.toptal.com/developers/gitignore/api/zsh,linux,macos,git
+# Edit at https://www.toptal.com/developers/gitignore?templates=zsh,linux,macos,git
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Zsh ###
+# Zsh compiled script + zrecompile backup
+*.zwc
+*.zwc.old
+
+# Zsh completion-optimization dumpfile
+*zcompdump*
+
+# Zsh history
+.zsh_history
+
+# Zsh sessions
+.zsh_sessions
+
+# Zsh zcalc history
+.zcalc_history
+
+# A popular plugin manager's files
+._zinit
+.zinit_lstupd
+
+# zdharma/zshelldoc tool's files
+zsdoc/data
+
+# robbyrussell/oh-my-zsh/plugins/per-directory-history plugin's files
+# (when set-up to store the history in the local directory)
+.directory_history
+
+# MichaelAquilina/zsh-autoswitch-virtualenv plugin's files
+# (for Zsh plugins using Python)
+.venv
+
+# Zunit tests' output
+/tests/_output/*
+!/tests/_output/.gitkeep
+
+# End of https://www.toptal.com/developers/gitignore/api/zsh,linux,macos,git

--- a/EasySetup.sh
+++ b/EasySetup.sh
@@ -8,7 +8,7 @@ create_dir(){
 basics(){
     sudo apt install update && \
     sudo apt install tmux vim git curl wget python3 python3-pip openvpn nmap jq zip unzip wfuzz dnsenum && \
-    sudo snap install seclists amass dalfox httpx;
+    sudo snap install seclists amass dalfox httpx insomnia;
 }
 
 get_rustscan(){
@@ -88,7 +88,7 @@ get_assetfinder(){
     mv /tmp/assetfinder/assetfinder $1/
 }
 
-
+TOOLS_PATH=$(create_dir);
 
 # Update existing packages
 echo -e "\nUpdating existing packages...\n" && sudo apt update && sudo apt upgrade -y && sudo apt autoremove -y
@@ -135,22 +135,16 @@ if [ "$answer" != "${answer#[Yy]}" ]; then
     sudo curl 'https://portswigger.net/burp/releases/download?product=community&version=2023.2.4&type=Linux' > burpsuite.sh && sudo chmod +x burpsuite.sh && ./burpsuite.sh
 fi
 
-# Install Insomnia
-read -p $'\n'"Do you want to install Insomnia? (y/n) " answer
-if [ "$answer" != "${answer#[Yy]}" ]; then
-    sudo snap install insomnia
-fi
-
 # Install Katana
 read -p $'\n'"Do you want to install Katana? (y/n) " answer
 if [ "$answer" != "${answer#[Yy]}" ]; then
-    git clone https://github.com/projectdiscovery/katana.git && cd ./katana/cmd/katana && go build && sudo mv katana /usr/bin/
+    get_katana($TOOLS_PATH);
 fi
 
 # Install SQLMap
 read -p $'\n'"Do you want to install SQLMap? (y/n) " answer
 if [ "$answer" != "${answer#[Yy]}" ]; then
-    git clone --depth 1 https://github.com/sqlmapproject/sqlmap.git sqlmap-dev && cd sqlmap-dev && sudo ln -s "$(pwd)/sqlmap.py" /usr/local/bin/sqlmap
+    get_sqlmap($TOOLS_PATH);
 fi
 
 # Install VSCode
@@ -164,4 +158,3 @@ read -p $'\n'"DO you want to install Dirhunt? (y/n) " answer
 if [ "$answer" != "${answer#[Yy]}" ]; then
     sudo pip3 install dirhunt
 fi
-


### PR DESCRIPTION
Esse PR implementa ajustes no .gitignore, que estava só com um exemplo e agora realmente contém uma lista de ignores válidos. No script foram substituídas algumas instalações que ocorriam diretamente no fluxo principal pelas instalações que ocorrem através de chamada de funções.

Exemplo

Assim seria o fluxo antigo:
```bash
# Instala dnsrato
if instaladnsrato = Y; then
    # comandos para instalar dnsrato
fi;
```

O fluxo novo ocorre desacoplando o fluxo de instalação do fluxo de escolha do user:
```bash
# function instala dnsrato
get_dnsrato(){
   # comandos para instalar dnsrato
}

# chamada da function get_dnsrato na parte principal do codigo
if instaladnsrato = y; then
    get_dnsrato;
fi;
```

Assim de cara parece estar dando mais voltas para fazer uma coisa simples (e realmente está). Porém, separando por funções fica mais simples de fazer manutenção do script.